### PR TITLE
Fixed Mapping.txt

### DIFF
--- a/Mapping.txt
+++ b/Mapping.txt
@@ -3,7 +3,7 @@ Mappings using MCP 7.22
 GuiIngameMenu           => aty.class
 GuiWDL                  => GuiWDL.class
 GuiWDLBackup            => GuiWDLBackup.class
-GuiWDLGenera=>r         => GuiWDLGenera=>r.class
+GuiWDLGenerator         => GuiWDLGenerator.class
 GuiWDLMultiworld        => GuiWDLMultiworld.class
 GuiWDLMultiworldSelect  => GuiWDLMultiworldSelect.class
 GuiWDLPlayer            => GuiWDLPlayer.class


### PR DESCRIPTION
The `to` inside `GuiWDLGenerator` was changed to `=>` when it shouldn't have been, presumably by a rogue script.
