### PR TITLE
added ChunkChangeObserver

### DIFF
--- a/litemod.json
+++ b/litemod.json
@@ -1,0 +1,11 @@
+{
+    "name": "WorldDownloader",
+    "mcversion": "1.7.10",
+    "version": "1.0.0",
+    "revision": "1000",
+    "author": "nairol, cubic72. MamiyaOtaru",
+    "description": "Download bits of multiplayer worlds you visit and save them for later use in singleplayer.",
+    "classTransformerClasses" : [
+        "wdl.litemod.WDLTransformer"
+    ]
+}

--- a/src/com/thevoxelbox/voxelmap/interfaces/AbstractVoxelMap.java
+++ b/src/com/thevoxelbox/voxelmap/interfaces/AbstractVoxelMap.java
@@ -1,0 +1,17 @@
+package com.thevoxelbox.voxelmap.interfaces;
+
+
+public abstract class AbstractVoxelMap implements IVoxelMap {
+	
+	public static AbstractVoxelMap instance = null;
+	
+	public static AbstractVoxelMap getInstance() {
+		return instance;
+	}
+
+}
+
+/* exists solely so I can provide getInstance() in a static context for other mods to be able to grab without
+needing to know about VoxelMap itself.  IVoxelMap as an interface cannot provide a method that can be accessed statically
+and I don't want people to need a stub of VoxelMap to compile against, so an interface plus a simple abstract class 
+to compile against seems the next best thing after just an interface */

--- a/src/com/thevoxelbox/voxelmap/interfaces/IObservableChunkChangeNotifier.java
+++ b/src/com/thevoxelbox/voxelmap/interfaces/IObservableChunkChangeNotifier.java
@@ -1,0 +1,13 @@
+package com.thevoxelbox.voxelmap.interfaces;
+
+import java.util.Observer;
+
+import net.minecraft.world.chunk.Chunk;
+
+public interface IObservableChunkChangeNotifier {
+
+	void chunkChanged(Chunk chunk);
+
+	void addObserver(Observer observer);
+
+}

--- a/src/com/thevoxelbox/voxelmap/interfaces/IVoxelMap.java
+++ b/src/com/thevoxelbox/voxelmap/interfaces/IVoxelMap.java
@@ -1,0 +1,8 @@
+package com.thevoxelbox.voxelmap.interfaces;
+
+public interface IVoxelMap {
+	
+
+	IObservableChunkChangeNotifier getNotifier();
+	
+}

--- a/src/wdl/ChunkChangeObserver.java
+++ b/src/wdl/ChunkChangeObserver.java
@@ -1,0 +1,32 @@
+package wdl;
+
+import java.util.Observable;
+import java.util.Observer;
+
+import net.minecraft.world.chunk.Chunk;
+
+public class ChunkChangeObserver implements Observer {
+	
+	public ChunkChangeObserver() {
+        if (classExists("com.thevoxelbox.voxelmap.interfaces.AbstractVoxelMap")) {
+        	com.thevoxelbox.voxelmap.interfaces.AbstractVoxelMap.getInstance().getNotifier().addObserver(this);
+        }
+	}
+
+	@Override
+	public void update(Observable o, Object arg) {
+		if (arg instanceof Chunk)
+			WDL.chunkChanged((Chunk)arg);
+	}
+	
+	public static boolean classExists(String className) {
+		try {
+			Class.forName (className);
+			return true;
+		}
+		catch (ClassNotFoundException exception) {
+			return false;
+		}
+	}
+
+}

--- a/src/wdl/litemod/LiteModWorldDownloader.java
+++ b/src/wdl/litemod/LiteModWorldDownloader.java
@@ -1,0 +1,217 @@
+package wdl.litemod;
+
+import java.io.File;
+import java.util.List;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiIngameMenu;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.entity.Entity;
+import net.minecraft.network.INetHandler;
+import net.minecraft.network.play.server.S01PacketJoinGame;
+import net.minecraft.network.play.server.S40PacketDisconnect;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.util.IntHashMap;
+import wdl.ReflectionUtils;
+import wdl.WDL;
+
+import com.mumfrey.liteloader.ChatListener;
+import com.mumfrey.liteloader.JoinGameListener;
+import com.mumfrey.liteloader.Permissible;
+import com.mumfrey.liteloader.Tickable;
+import com.mumfrey.liteloader.permissions.PermissionsManager;
+import com.mumfrey.liteloader.permissions.PermissionsManagerClient;
+import com.mumfrey.liteloader.transformers.event.EventInfo;
+import com.mumfrey.liteloader.transformers.event.ReturnEventInfo;
+
+public class LiteModWorldDownloader implements JoinGameListener, Tickable, Permissible, ChatListener 
+{
+
+	private long lastTick = 0;
+	private boolean hasVoxelPlugins = true;
+	
+	private boolean canCacheChunks = true;
+	
+	//private PacketHandler packetHandler; // can be used to get name of multiverse world from voxel plugin installed on server (if any)
+	
+	public LiteModWorldDownloader()
+	{
+	}
+		
+	@Override
+	public String getName()
+	{
+		return "WorldDownloader";
+	}
+	
+	@Override
+	public String getVersion()
+	{
+		return "1.0.0";
+	}
+	
+	@Override
+	public void init(File configPath)
+	{
+/*		hasVoxelPlugins = hasVoxelPlugins && ReflectionUtils.classExists("com.thevoxelbox.voxelpacket.client.VoxelPacketClient");
+		hasVoxelPlugins = hasVoxelPlugins && ReflectionUtils.classExists("com.thevoxelbox.voxelpacket.common.VoxelMessage");
+		hasVoxelPlugins = hasVoxelPlugins && ReflectionUtils.classExists("com.thevoxelbox.voxelpacket.common.interfaces.IVoxelMessagePublisher");
+		hasVoxelPlugins = hasVoxelPlugins && ReflectionUtils.classExists("com.thevoxelbox.voxelpacket.common.interfaces.IVoxelMessageSubscriber");
+		if (hasVoxelPlugins)
+			packetHandler = new PacketHandler(configPath);*/
+	}
+
+	@Override
+	public void upgradeSettings(String version, File configPath, File oldConfigPath)
+	{
+	}
+	
+	@Override
+	public void onTick(Minecraft minecraft, float partialTicks, boolean inGame,	boolean clock) {
+        if( WDL.mc.theWorld != WDL.wc ) {
+        	if (WDL.mc.theWorld == null) {
+        		WDL.stop();
+        		WDL.wc = null;
+        	}
+        	else {
+        		WDL.onWorldLoad();
+        	}
+        }
+	}
+	
+	/* (non-Javadoc)
+	 * @see net.minecraft.src.BaseMod#serverConnect(net.minecraft.src.NetClientHandler)
+	 */
+	@Override
+	public void onJoinGame(INetHandler netHandler, S01PacketJoinGame joinGamePacket) {
+	//	if (hasVoxelPlugins && packetHandler != null) {
+	//		packetHandler.onServerConnect(netHandler);
+	//	}
+	}
+
+    @Override
+    public String getPermissibleModName() {
+    	return getName().toLowerCase();
+    }
+
+    @Override
+    public float getPermissibleModVersion() {
+    	return Float.parseFloat(getVersion().replace(".", ""));
+    }
+
+    @Override
+    public void registerPermissions(PermissionsManagerClient permissionsManager) {
+    	permissionsManager.registerModPermission(this, "cachechunks");
+    }
+
+    @Override
+    public void onPermissionsCleared(PermissionsManager manager) {
+    	canCacheChunks = true;
+    }
+
+    @Override
+    public void onPermissionsChanged(PermissionsManager manager) {
+    	canCacheChunks = ((PermissionsManagerClient)manager).getModPermission(this, "cachechunks");
+    	// same as
+    	//canCacheChunks = manager.getPermissions(this).getHasPermission("mod.worlddownloader.cachechunks");
+ // TODO   	WDL.setPermissions(canCacheChunks);
+    }
+
+	@Override
+	public void onChat(IChatComponent chat, String message) {
+		WDL.handleServerSeedMessage(message);
+	}
+	
+	
+	
+	
+    public static void initGui(EventInfo<GuiIngameMenu> e) {
+    	GuiIngameMenu ingameMenu = e.getSource();
+    	List buttonList = (List)ReflectionUtils.getPrivateFieldValueByType(ingameMenu, GuiScreen.class, List.class);
+        WDL.injectWDLButtons(ingameMenu, buttonList);
+    }
+
+    public static void actionPerformed(EventInfo<GuiIngameMenu> e, GuiButton p_146284_1_) {
+        WDL.handleWDLButtonClick(e.getSource(), p_146284_1_);
+    }
+    
+    public static void tick(EventInfo<WorldClient> e) {
+        if( wdl.WDL.downloading )
+        {
+            if( wdl.WDL.tp.openContainer != wdl.WDL.windowContainer )
+            {
+                if( wdl.WDL.tp.openContainer == wdl.WDL.tp.inventoryContainer )
+                    wdl.WDL.onItemGuiClosed();
+                else
+                    wdl.WDL.onItemGuiOpened();
+                wdl.WDL.windowContainer = wdl.WDL.tp.openContainer;
+            }
+        }
+    }
+    
+    public static void doPreChunk(EventInfo<WorldClient> e, int p_73025_1_, int p_73025_2_, boolean p_73025_3_) {
+    	WorldClient wc = e.getSource();
+        if (p_73025_3_)
+        {
+            if( wc != wdl.WDL.wc ) wdl.WDL.onWorldLoad();
+        }
+        else
+        {
+            if( wdl.WDL.downloading ) wdl.WDL.onChunkNoLongerNeeded( wc.getChunkProvider().provideChunk(p_73025_1_, p_73025_2_) );
+        }
+    }
+    
+    public static void removeEntityFromWorld(ReturnEventInfo<WorldClient, ?> e, int p_73028_1_) {
+    	WorldClient wc = e.getSource();
+    	IntHashMap entityHashSet = (IntHashMap)ReflectionUtils.getPrivateFieldValueByType(wc, WorldClient.class, IntHashMap.class);
+        Entity var2 = (Entity)entityHashSet.lookup(p_73028_1_); // lookup instead of removeObject so removeObject has something to remove when the actual method runs
+        
+        if(wdl.WDL.shouldKeepEntity(var2)) 
+        {
+        	entityHashSet.removeObject(p_73028_1_); // remove for real since we'll be canceling the actual method (in which it would have been removed regardless)
+        	e.setReturnValue(null);
+        }
+    }
+    
+    public static void addBlockEvent(EventInfo<WorldClient> e, int par1, int par2, int par3, Block par4, int par5, int par6) {
+        if( wdl.WDL.downloading )
+            wdl.WDL.onBlockEvent( par1, par2, par3, par4, par5, par6 );
+    }
+    
+    public static void handleDisconnect(EventInfo<NetHandlerPlayClient> e, S40PacketDisconnect arg1) {
+        if (wdl.WDL.downloading)
+        {
+            wdl.WDL.stop();
+
+            try
+            {
+                Thread.sleep(2000L);
+            }
+            catch (Exception var3)
+            {
+                ;
+            }
+        }
+    }
+    
+    public static void onDisconnect(EventInfo<NetHandlerPlayClient> e, IChatComponent arg1) {
+        if (wdl.WDL.downloading)
+        {
+            wdl.WDL.stop();
+
+            try
+            {
+                Thread.sleep(2000L);
+            }
+            catch (Exception var3)
+            {
+                ;
+            }
+        }
+    }
+
+}

--- a/src/wdl/litemod/WDLObfuscationTable.java
+++ b/src/wdl/litemod/WDLObfuscationTable.java
@@ -1,0 +1,42 @@
+package wdl.litemod;
+
+import com.mamiyaotaru.chatbubbles.litemod.ChatBubblesObfuscationTable;
+import com.mumfrey.liteloader.core.runtime.Obf;
+
+public class WDLObfuscationTable extends Obf {
+		
+	public static WDLObfuscationTable GuiIngameMenu = new WDLObfuscationTable("net.minecraft.client.gui.GuiIngameMenu", "bdp");
+	public static WDLObfuscationTable GuiButton = new WDLObfuscationTable("net.minecraft.client.gui.GuiButton", "bcb");
+	public static WDLObfuscationTable initGui = new WDLObfuscationTable("func_73866_w_", "b", "initGui");
+	public static WDLObfuscationTable actionPerformed = new WDLObfuscationTable("func_146284_a", "a", "actionPerformed");
+	
+	public static WDLObfuscationTable World = new WDLObfuscationTable("net.minecraft.world.World", "ahb");
+	public static WDLObfuscationTable WorldClient = new WDLObfuscationTable("net.minecraft.client.multiplayer.WorldClient", "bjf");
+	public static WDLObfuscationTable Block = new WDLObfuscationTable("net.minecraft.block.Block", "aji");
+	public static WDLObfuscationTable Entity = new WDLObfuscationTable("net.minecraft.entity.Entity", "sa");
+	public static WDLObfuscationTable tick = new WDLObfuscationTable("func_72835_b", "b", "tick");
+	public static WDLObfuscationTable doPreChunk = new WDLObfuscationTable("func_73025_a", "a", "doPreChunk");
+	public static WDLObfuscationTable removeEntityFromWorld = new WDLObfuscationTable("func_73028_b", "b", "removeEntityFromWorld");
+	public static WDLObfuscationTable addBlockEvent = new WDLObfuscationTable("func_147452_c", "c", "addBlockEvent");
+
+	public static WDLObfuscationTable NetHandlerPlayClient = new WDLObfuscationTable("net.minecraft.client.network.NetHandlerPlayClient", "bjb");
+	public static WDLObfuscationTable S40PacketDisconnect = new WDLObfuscationTable("net.minecraft.network.play.server.S40PacketDisconnect", "gs");
+	public static WDLObfuscationTable IChatComponent = new WDLObfuscationTable("net.minecraft.util.IChatComponent", "fj");
+	public static WDLObfuscationTable handleDisconnect = new WDLObfuscationTable("func_147253_a", "a", "handleDisconnect");
+	public static WDLObfuscationTable onDisconnect = new WDLObfuscationTable("func_147231_a", "a", "onDisconnect");
+
+	//WorldClient
+	//addBlockEvent
+	protected WDLObfuscationTable(String name) {
+		super(name, name, name);
+	}
+	
+	protected WDLObfuscationTable(String seargeName, String obfName) {
+		super(seargeName, obfName, seargeName);
+	}
+	
+	protected WDLObfuscationTable(String seargeName, String obfName, String mcpName) {
+		super(seargeName, obfName, mcpName);
+	}
+
+}

--- a/src/wdl/litemod/WDLTransformer.java
+++ b/src/wdl/litemod/WDLTransformer.java
@@ -1,0 +1,73 @@
+package wdl.litemod;
+
+import com.mumfrey.liteloader.core.runtime.Obf;
+import com.mumfrey.liteloader.transformers.event.Event;
+import com.mumfrey.liteloader.transformers.event.EventInjectionTransformer;
+import com.mumfrey.liteloader.transformers.event.MethodInfo;
+import com.mumfrey.liteloader.transformers.event.inject.BeforeReturn;
+import com.mumfrey.liteloader.transformers.event.inject.MethodHead;
+
+public class WDLTransformer extends EventInjectionTransformer {
+
+	@Override
+	protected void addEvents() {
+		
+		/*
+		Event onlineConnectTaskConstructorEvent = Event.getOrCreate("connectToRealms");
+		MethodInfo onlineConnectTaskConstructorMethod = new MethodInfo(VoxelMapObfuscationTable.OnlineConnectTask, Obf.constructor, Void.TYPE, VoxelMapObfuscationTable.RealmsScreen, VoxelMapObfuscationTable.McoServer);
+		BeforeReturn beforeReturn = new BeforeReturn();
+		this.addEvent(onlineConnectTaskConstructorEvent, onlineConnectTaskConstructorMethod, beforeReturn);
+		
+		onlineConnectTaskConstructorEvent.addListener(new MethodInfo("com.thevoxelbox.voxelmap.litemod.LiteModVoxelMap", "connectedToRealmsWithServer"));
+		*/
+				
+		Event initGuiEvent = Event.getOrCreate("initIngameMenu");
+		MethodInfo initGuiMethod = new MethodInfo(WDLObfuscationTable.GuiIngameMenu, WDLObfuscationTable.initGui, Void.TYPE);
+		BeforeReturn beforeReturn = new BeforeReturn();
+		this.addEvent(initGuiEvent, initGuiMethod, beforeReturn);
+		initGuiEvent.addListener(new MethodInfo("wdl.litemod.LiteModWorldDownloader", "initGui"));
+		
+		Event actionPerformedEvent = Event.getOrCreate("ingameMenuActionPerformed");
+		MethodInfo actionPerformedMethod = new MethodInfo(WDLObfuscationTable.GuiIngameMenu, WDLObfuscationTable.actionPerformed, Void.TYPE, WDLObfuscationTable.GuiButton);
+		MethodHead methodHead = new MethodHead();
+		this.addEvent(actionPerformedEvent, actionPerformedMethod, methodHead);
+		actionPerformedEvent.addListener(new MethodInfo("wdl.litemod.LiteModWorldDownloader", "actionPerformed"));
+
+		Event tickEvent = Event.getOrCreate("worldClientTick");
+		MethodInfo tickMethod = new MethodInfo(WDLObfuscationTable.WorldClient, WDLObfuscationTable.tick, Void.TYPE);
+		//BeforeReturn beforeReturn = new BeforeReturn();
+		this.addEvent(tickEvent, tickMethod, beforeReturn);
+		tickEvent.addListener(new MethodInfo("wdl.litemod.LiteModWorldDownloader", "tick"));
+		
+		Event doPreChunkEvent = Event.getOrCreate("preChunkEvent");
+		MethodInfo doPreChunkMethod = new MethodInfo(WDLObfuscationTable.WorldClient, WDLObfuscationTable.doPreChunk, Void.TYPE, Integer.TYPE, Integer.TYPE, Boolean.TYPE);
+		//MethodHead methodHead = new MethodHead();
+		this.addEvent(doPreChunkEvent, doPreChunkMethod, methodHead);
+		doPreChunkEvent.addListener(new MethodInfo("wdl.litemod.LiteModWorldDownloader", "doPreChunk"));
+		
+		Event removeEntityFromWorldEvent = Event.getOrCreate("removingEntity", true);
+		MethodInfo removeEntityFromWorldMethod = new MethodInfo(WDLObfuscationTable.WorldClient, WDLObfuscationTable.removeEntityFromWorld, WDLObfuscationTable.Entity, Integer.TYPE);
+		//MethodHead methodHead = new MethodHead();
+		this.addEvent(removeEntityFromWorldEvent, removeEntityFromWorldMethod, methodHead);
+		removeEntityFromWorldEvent.addListener(new MethodInfo("wdl.litemod.LiteModWorldDownloader", "removeEntityFromWorld"));
+		
+		Event addBlockEvent = Event.getOrCreate("addingBlock");
+		MethodInfo addBlockMethod = new MethodInfo(WDLObfuscationTable.World, WDLObfuscationTable.addBlockEvent, Void.TYPE, Integer.TYPE, Integer.TYPE, Integer.TYPE, WDLObfuscationTable.Block, Integer.TYPE, Integer.TYPE);
+		//BeforeReturn beforeReturn = new BeforeReturn();
+		this.addEvent(addBlockEvent, addBlockMethod, beforeReturn);
+		addBlockEvent.addListener(new MethodInfo("wdl.litemod.LiteModWorldDownloader", "addBlockEvent"));
+
+		Event handleDisconnectEvent = Event.getOrCreate("handlingDisconnecting");
+		MethodInfo handleDisconnectMethod = new MethodInfo(WDLObfuscationTable.NetHandlerPlayClient, WDLObfuscationTable.handleDisconnect, Void.TYPE, WDLObfuscationTable.S40PacketDisconnect);
+		//MethodHead methodHead = new MethodHead();
+		this.addEvent(handleDisconnectEvent, handleDisconnectMethod, methodHead);
+		handleDisconnectEvent.addListener(new MethodInfo("wdl.litemod.LiteModWorldDownloader", "handleDisconnect"));
+		
+		Event onDisconnectEvent = Event.getOrCreate("onDisconnecting");
+		MethodInfo onDisconnectMethod = new MethodInfo(WDLObfuscationTable.NetHandlerPlayClient, WDLObfuscationTable.onDisconnect, Void.TYPE, WDLObfuscationTable.IChatComponent);
+		//MethodHead methodHead = new MethodHead();
+		this.addEvent(onDisconnectEvent, onDisconnectMethod, methodHead);
+		onDisconnectEvent.addListener(new MethodInfo("wdl.litemod.LiteModWorldDownloader", "onDisconnect"));
+	}
+
+}


### PR DESCRIPTION
WDL gets changed chunks from VoxelMap (if and only if it exists), allowing both to use isChanged
Also updated to some more recent MCPtest mappings

First two commits are the observer changes, and stubs for voxelmap against which to compile.  

Because I suck at Git, the third commit is completely separate, and represents a drop-in liteloader replacement for all the base class edits (which is slightly redundant, given that I have since discovered someone else has created the same thing)
